### PR TITLE
Fix workspace switching bug by ensuring workspace exists before activ…

### DIFF
--- a/src/state/model.rs
+++ b/src/state/model.rs
@@ -152,9 +152,15 @@ impl MinimapState {
 
         // Set new active state
         self.active_workspace_id = Some(workspace_id);
-        if let Some(workspace) = self.workspaces.get_mut(&workspace_id) {
-            workspace.is_active = true;
-        }
+
+        // Ensure the workspace exists (create if necessary for dynamically created workspaces)
+        let workspace = self.workspaces.entry(workspace_id).or_insert_with(|| {
+            Workspace {
+                id: workspace_id,
+                ..Default::default()
+            }
+        });
+        workspace.is_active = true;
     }
 
     /// Clear all state


### PR DESCRIPTION
…ation

When Niri dynamically creates new workspaces, set_active_workspace() was attempting to activate workspaces that didn't exist in the HashMap yet. This caused active_workspace() to return None, making the minimap calculate zero dimensions and stop appearing after switching workspaces.

The fix ensures the workspace exists by creating it if necessary using the entry API, similar to the pattern used in upsert_window().

Fixes #2