### PR TITLE
Remove unused code to fix compiler warnings

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -210,10 +210,4 @@ impl Color {
             a: 1.0,
         })
     }
-
-    /// Create a color with modified alpha
-    pub fn with_alpha(mut self, alpha: f64) -> Self {
-        self.a = alpha;
-        self
-    }
 }

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -38,15 +38,6 @@ impl NiriClient {
         }
     }
 
-    /// Query the focused window
-    pub fn get_focused_window(&mut self) -> Result<Option<niri_ipc::Window>> {
-        let reply = self.send(Request::FocusedWindow)?;
-        match reply {
-            Response::FocusedWindow(window) => Ok(window),
-            other => anyhow::bail!("Unexpected response for FocusedWindow request: {:?}", other),
-        }
-    }
-
     /// Send a request and get a response
     fn send(&mut self, request: Request) -> Result<Response> {
         let reply: Reply = self

--- a/src/ipc/events.rs
+++ b/src/ipc/events.rs
@@ -67,8 +67,6 @@ fn fetch_initial_state() -> Result<MinimapState> {
     // Process workspaces
     for ws in workspaces {
         let workspace = Workspace {
-            id: ws.id,
-            name: ws.name,
             is_active: ws.is_focused, // is_focused means it's the globally focused workspace
             ..Default::default()
         };
@@ -210,8 +208,6 @@ fn niri_window_to_model(win: &niri_ipc::Window) -> Window {
 
     Window {
         id: win.id,
-        app_id: win.app_id.clone().unwrap_or_default(),
-        title: win.title.clone().unwrap_or_default(),
         pos,
         size: layout.tile_size,
         column_index,

--- a/src/state/model.rs
+++ b/src/state/model.rs
@@ -5,10 +5,6 @@ use std::collections::HashMap;
 pub struct Window {
     /// Unique window identifier from Niri
     pub id: u64,
-    /// Application identifier (e.g., "firefox", "alacritty")
-    pub app_id: String,
-    /// Window title
-    pub title: String,
     /// Position in workspace view coordinates (x, y)
     pub pos: (f64, f64),
     /// Window tile size (width, height)
@@ -26,53 +22,12 @@ pub struct Window {
 /// Represents a workspace containing windows
 #[derive(Debug, Clone, Default)]
 pub struct Workspace {
-    /// Workspace unique identifier
-    pub id: u64,
-    /// Workspace name (if set)
-    pub name: Option<String>,
     /// Windows in this workspace, keyed by window ID
     pub windows: HashMap<u64, Window>,
     /// Whether this workspace is currently active
     pub is_active: bool,
 }
 
-impl Workspace {
-    /// Calculate the total width of all columns in the workspace
-    pub fn total_width(&self) -> f64 {
-        if self.windows.is_empty() {
-            return 0.0;
-        }
-
-        let mut max_x = 0.0f64;
-        for window in self.windows.values() {
-            let right_edge = window.pos.0 + window.size.0;
-            max_x = max_x.max(right_edge);
-        }
-        max_x
-    }
-
-    /// Calculate the total height of the workspace
-    pub fn total_height(&self) -> f64 {
-        if self.windows.is_empty() {
-            return 0.0;
-        }
-
-        let mut max_y = 0.0f64;
-        for window in self.windows.values() {
-            let bottom_edge = window.pos.1 + window.size.1;
-            max_y = max_y.max(bottom_edge);
-        }
-        max_y
-    }
-
-    /// Get the minimum X position (leftmost window edge)
-    pub fn min_x(&self) -> f64 {
-        self.windows
-            .values()
-            .map(|w| w.pos.0)
-            .fold(f64::INFINITY, f64::min)
-    }
-}
 
 /// Main state container for the minimap
 #[derive(Debug, Clone, Default)]
@@ -83,8 +38,6 @@ pub struct MinimapState {
     pub active_workspace_id: Option<u64>,
     /// Currently focused window ID
     pub focused_window_id: Option<u64>,
-    /// Output/monitor name this minimap is displaying
-    pub output_name: Option<String>,
 }
 
 impl MinimapState {
@@ -109,7 +62,6 @@ impl MinimapState {
     pub fn upsert_window(&mut self, workspace_id: u64, window: Window) {
         let workspace = self.workspaces.entry(workspace_id).or_insert_with(|| {
             Workspace {
-                id: workspace_id,
                 ..Default::default()
             }
         });
@@ -158,17 +110,9 @@ impl MinimapState {
         // Ensure the workspace exists (create if necessary for dynamically created workspaces)
         let workspace = self.workspaces.entry(workspace_id).or_insert_with(|| {
             Workspace {
-                id: workspace_id,
                 ..Default::default()
             }
         });
         workspace.is_active = true;
-    }
-
-    /// Clear all state
-    pub fn clear(&mut self) {
-        self.workspaces.clear();
-        self.active_workspace_id = None;
-        self.focused_window_id = None;
     }
 }

--- a/src/ui/minimap.rs
+++ b/src/ui/minimap.rs
@@ -120,11 +120,6 @@ impl MinimapWidget {
         }
     }
 
-    /// Check if minimap should always be visible
-    pub fn is_always_visible(&self) -> bool {
-        self.config.borrow().behavior.always_visible
-    }
-
     /// Reload the configuration from disk
     pub fn reload_config(&self) {
         match Config::load() {


### PR DESCRIPTION
### Summary

Removes all unused methods, functions, and struct fields identified by the Rust compiler to eliminate the 8 dead code warnings.

### Changes

- Removed `Color::with_alpha` method
- Removed `NiriClient::get_focused_window` method
- Removed `Window::app_id` and `Window::title` fields
- Removed `Workspace::id`, `name` fields and `total_width`, `total_height`, `min_x` methods
- Removed `MinimapState::output_name` field and `clear` method
- Removed `MinimapWidget::is_always_visible` method

Fixes #10

🤖 Generated with [Claude Code](https://claude.ai/code)