### PR TITLE
Overview-style multi-workspace rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,14 @@ A minimal workspace minimap overlay for the [Niri](https://github.com/YaLTeR/nir
 
 ## Features
 
-- Displays a minimap of your current workspace showing window layout
+- Displays a minimap of your workspaces showing window layout
+- Two display modes: show every workspace stacked vertically (Overview-style) or only the active one
 - Renders as an overlay layer surface (visible over fullscreen windows)
 - Click-through design (doesn't intercept mouse events)
 - Configurable appearance (colors, borders, gaps, opacity)
 - Configurable visibility behavior (always visible or show on events)
 - Hot-reloads configuration changes
-- Dynamic width based on workspace content
+- Dynamic sizing based on workspace content
 
 ## Installation
 
@@ -62,12 +63,17 @@ Configuration file is located at `~/.config/nirimap/config.toml`. A default conf
 
 ```toml
 [display]
-height = 100                # Minimap height in pixels (width is dynamic)
+height = 100                # Per-workspace row height in pixels
+                            # "current" mode: whole widget height
+                            # "all" mode: height of a single workspace row
 max_width_percent = 0.5     # Maximum width as fraction of screen (0.0 - 1.0)
+max_height_percent = 0.8    # Maximum height as fraction of screen ("all" mode)
 anchor = "top-right"        # Position: top-left, top-center, top-right,
                             #           bottom-left, bottom-center, bottom-right, center
 margin_x = 10               # Horizontal margin from edge
 margin_y = 10               # Vertical margin from edge
+workspace_mode = "all"      # "all"     - stack every workspace vertically (default)
+                            # "current" - show only the active workspace
 
 [appearance]
 background = "#1e1e2e"    # Background color (hex)
@@ -77,13 +83,28 @@ border_color = "#6c7086"  # Window border color
 border_width = 1            # Window border thickness
 border_radius = 2           # Corner radius for window rectangles
 gap = 2                     # Gap between windows (in minimap pixels)
-background_opacity = 0.9    # Background opacity (0.0 = transparent, 1.0 = opaque)
+background_opacity = 0.0    # Background opacity (0.0 = transparent, 1.0 = opaque)
+                            # Applies in both "current" and "all" modes
+window_opacity = 0.7        # Fill opacity for unfocused windows (0 = outlines only)
+focused_opacity = 1.0       # Fill opacity for the focused window
+workspace_gap = 4                           # Vertical gap between stacked workspaces ("all" mode)
+active_workspace_border_color = "#89b4fa"   # Highlight border for the active workspace ("all" mode)
+active_workspace_border_width = 2           # Highlight border thickness ("all" mode)
 
 [behavior]
 show_on_overview = true     # Keep visible in Niri overview mode (not yet implemented)
 always_visible = true       # Always show minimap (false = only on events)
 hide_timeout_ms = 2000      # Milliseconds before hiding after an event
 ```
+
+### Workspace Display Modes
+
+Two display modes control what the minimap shows:
+
+- **`all`** (default) — every workspace is rendered as a row, stacked vertically in Niri's workspace order (like Niri's Overview feature). The active workspace is highlighted with a border so you can see where focus is at a glance.
+- **`current`** — only the active workspace is rendered. The widget height equals `display.height` and the minimap content changes as you switch workspaces. This is the classic nirimap behavior.
+
+In `all` mode the total widget height grows with the number of workspaces, capped at `max_height_percent` of the monitor's height. When the cap is hit, per-workspace rows shrink proportionally to fit.
 
 ### Hot Reload
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,20 +16,36 @@ pub enum Anchor {
     Center,
 }
 
+/// Which workspaces the minimap renders
+#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum WorkspaceMode {
+    /// Render only the currently active workspace
+    Current,
+    /// Render every workspace stacked vertically (Overview-style)
+    #[default]
+    All,
+}
+
 /// Display configuration
 #[derive(Debug, Clone, Deserialize)]
 #[serde(default)]
 pub struct DisplayConfig {
-    /// Minimap height in pixels (width is calculated dynamically)
+    /// Per-workspace row height in pixels. In `current` mode this is the whole
+    /// widget height; in `all` mode it is the height of a single workspace row.
     pub height: u32,
     /// Maximum width as percentage of screen width (0.0 - 1.0)
     pub max_width_percent: f64,
+    /// Maximum height as percentage of screen height (0.0 - 1.0), used in `all` mode
+    pub max_height_percent: f64,
     /// Position anchor
     pub anchor: Anchor,
     /// Horizontal margin from edge
     pub margin_x: i32,
     /// Vertical margin from edge
     pub margin_y: i32,
+    /// Which workspaces to display
+    pub workspace_mode: WorkspaceMode,
 }
 
 impl Default for DisplayConfig {
@@ -37,9 +53,11 @@ impl Default for DisplayConfig {
         Self {
             height: 100,
             max_width_percent: 0.5,
+            max_height_percent: 0.8,
             anchor: Anchor::TopRight,
             margin_x: 10,
             margin_y: 10,
+            workspace_mode: WorkspaceMode::default(),
         }
     }
 }
@@ -64,6 +82,16 @@ pub struct AppearanceConfig {
     pub gap: f64,
     /// Background opacity (0.0 = transparent, 1.0 = opaque)
     pub background_opacity: f64,
+    /// Fill opacity for unfocused windows (0.0 = transparent, just borders)
+    pub window_opacity: f64,
+    /// Fill opacity for the focused window
+    pub focused_opacity: f64,
+    /// Vertical gap between stacked workspaces in `all` mode
+    pub workspace_gap: f64,
+    /// Border color for the active workspace in `all` mode (hex)
+    pub active_workspace_border_color: String,
+    /// Border thickness for the active workspace in `all` mode
+    pub active_workspace_border_width: f64,
 }
 
 impl Default for AppearanceConfig {
@@ -76,7 +104,12 @@ impl Default for AppearanceConfig {
             border_width: 1.0,
             border_radius: 2.0,
             gap: 2.0,
-            background_opacity: 0.9,
+            background_opacity: 0.0,
+            window_opacity: 0.7,
+            focused_opacity: 1.0,
+            workspace_gap: 4.0,
+            active_workspace_border_color: "#89b4fa".to_string(),
+            active_workspace_border_width: 2.0,
         }
     }
 }
@@ -153,12 +186,18 @@ impl Config {
         }
 
         let default_config = r##"[display]
-height = 100              # Minimap height in pixels (width is dynamic)
+height = 100              # Per-workspace row height in pixels
+                          # In "current" mode: total widget height
+                          # In "all" mode: height of one workspace row
 max_width_percent = 0.5   # Maximum width as fraction of screen (0.0 - 1.0)
+max_height_percent = 0.8  # Maximum height as fraction of screen (used in "all" mode)
 anchor = "top-right"      # Position: top-left, top-center, top-right,
                           #           bottom-left, bottom-center, bottom-right, center
 margin_x = 10             # Horizontal margin from edge
 margin_y = 10             # Vertical margin from edge
+workspace_mode = "all"    # Which workspaces to show:
+                          #   "all"     - stack every workspace vertically (Overview-style)
+                          #   "current" - show only the active workspace
 
 [appearance]
 background = "#1e1e2e"    # Background color (hex)
@@ -168,7 +207,13 @@ border_color = "#6c7086"  # Window border color
 border_width = 1          # Window border thickness
 border_radius = 2         # Corner radius for window rectangles
 gap = 2                   # Gap between windows (in minimap pixels)
-background_opacity = 0.9  # Background opacity (0.0 = transparent, 1.0 = opaque)
+background_opacity = 0.0  # Background opacity (0.0 = transparent, 1.0 = opaque)
+                          # Applies in both "current" and "all" modes
+window_opacity = 0.7      # Fill opacity for unfocused windows (0 = outlines only)
+focused_opacity = 1.0     # Fill opacity for the focused window
+workspace_gap = 4                            # Vertical gap between stacked workspaces ("all" mode)
+active_workspace_border_color = "#89b4fa"    # Highlight border for active workspace ("all" mode)
+active_workspace_border_width = 2            # Highlight border thickness ("all" mode)
 
 [behavior]
 show_on_overview = true   # Keep visible in Niri overview mode
@@ -227,9 +272,11 @@ mod tests {
         // Test display defaults
         assert_eq!(config.display.height, 100);
         assert_eq!(config.display.max_width_percent, 0.5);
+        assert_eq!(config.display.max_height_percent, 0.8);
         assert_eq!(config.display.anchor, Anchor::TopRight);
         assert_eq!(config.display.margin_x, 10);
         assert_eq!(config.display.margin_y, 10);
+        assert_eq!(config.display.workspace_mode, WorkspaceMode::All);
 
         // Test appearance defaults
         assert_eq!(config.appearance.background, "#1e1e2e");
@@ -239,7 +286,12 @@ mod tests {
         assert_eq!(config.appearance.border_width, 1.0);
         assert_eq!(config.appearance.border_radius, 2.0);
         assert_eq!(config.appearance.gap, 2.0);
-        assert_eq!(config.appearance.background_opacity, 0.9);
+        assert_eq!(config.appearance.background_opacity, 0.0);
+        assert_eq!(config.appearance.window_opacity, 0.7);
+        assert_eq!(config.appearance.focused_opacity, 1.0);
+        assert_eq!(config.appearance.workspace_gap, 4.0);
+        assert_eq!(config.appearance.active_workspace_border_color, "#89b4fa");
+        assert_eq!(config.appearance.active_workspace_border_width, 2.0);
 
         // Test behavior defaults
         assert!(config.behavior.show_on_overview);
@@ -263,6 +315,27 @@ mod tests {
         "#;
         let config: Config = toml::from_str(toml).unwrap();
         assert_eq!(config.display.anchor, Anchor::BottomCenter);
+    }
+
+    #[test]
+    fn test_workspace_mode_deserialization() {
+        let toml = r#"
+            [display]
+            workspace_mode = "current"
+        "#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert_eq!(config.display.workspace_mode, WorkspaceMode::Current);
+
+        let toml = r#"
+            [display]
+            workspace_mode = "all"
+        "#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert_eq!(config.display.workspace_mode, WorkspaceMode::All);
+
+        // Default should be All
+        let config = Config::default();
+        assert_eq!(config.display.workspace_mode, WorkspaceMode::All);
     }
 
     #[test]

--- a/src/ipc/events.rs
+++ b/src/ipc/events.rs
@@ -23,6 +23,13 @@ pub enum StateUpdate {
     WorkspaceActivated { id: u64, focused: bool },
     /// Window layouts changed
     LayoutsChanged(Vec<(u64, niri_ipc::WindowLayout)>),
+    /// Workspace configuration changed (add/remove/reorder)
+    WorkspacesChanged(Vec<niri_ipc::Workspace>),
+    /// The active window on some workspace changed
+    WorkspaceActiveWindowChanged {
+        workspace_id: u64,
+        active_window_id: Option<u64>,
+    },
 }
 
 /// Run the event loop, sending state updates to the provided sender
@@ -79,7 +86,11 @@ fn fetch_initial_state() -> Result<MinimapState> {
     // Process workspaces
     for ws in workspaces {
         let workspace = Workspace {
-            is_active: ws.is_focused, // is_focused means it's the globally focused workspace
+            id: ws.id,
+            idx: ws.idx,
+            output: ws.output.clone(),
+            is_active: ws.is_active,
+            active_window_id: ws.active_window_id,
             ..Default::default()
         };
         state.workspaces.insert(ws.id, workspace);
@@ -206,6 +217,14 @@ fn event_to_update(event: Event) -> Option<StateUpdate> {
             Some(StateUpdate::WorkspaceActivated { id, focused })
         }
         Event::WindowLayoutsChanged { changes } => Some(StateUpdate::LayoutsChanged(changes)),
+        Event::WorkspacesChanged { workspaces } => Some(StateUpdate::WorkspacesChanged(workspaces)),
+        Event::WorkspaceActiveWindowChanged {
+            workspace_id,
+            active_window_id,
+        } => Some(StateUpdate::WorkspaceActiveWindowChanged {
+            workspace_id,
+            active_window_id,
+        }),
         // Ignore other events for now
         _ => None,
     }
@@ -224,12 +243,9 @@ fn niri_window_to_model(win: &niri_ipc::Window) -> Window {
         .map(|(c, w)| validate_and_convert_indices(c, w, win.id))
         .unwrap_or((0, 0));
 
-    // Extract position in workspace view
-    let pos = layout.tile_pos_in_workspace_view.unwrap_or((0.0, 0.0));
-
     Window {
         id: win.id,
-        pos,
+        pos: layout.tile_pos_in_workspace_view,
         size: layout.tile_size,
         column_index,
         window_index,

--- a/src/main.rs
+++ b/src/main.rs
@@ -276,13 +276,36 @@ fn apply_state_update(minimap: &MinimapWidget, update: StateUpdate) {
             }
         }
 
+        StateUpdate::WorkspacesChanged(workspaces) => {
+            minimap.update_state(|state| {
+                state.replace_workspace_metadata(&workspaces);
+            });
+            tracing::debug!("Workspaces changed ({} total)", workspaces.len());
+        }
+
+        StateUpdate::WorkspaceActiveWindowChanged {
+            workspace_id,
+            active_window_id,
+        } => {
+            minimap.update_state(|state| {
+                if let Some(ws) = state.workspaces.get_mut(&workspace_id) {
+                    ws.active_window_id = active_window_id;
+                }
+            });
+            tracing::debug!(
+                "Workspace {} active window -> {:?}",
+                workspace_id,
+                active_window_id
+            );
+        }
+
         StateUpdate::LayoutsChanged(layouts) => {
             minimap.update_state(|state| {
                 for (window_id, layout) in layouts {
                     // Find and update the window's layout
                     for workspace in state.workspaces.values_mut() {
                         if let Some(window) = workspace.windows.get_mut(&window_id) {
-                            window.pos = layout.tile_pos_in_workspace_view.unwrap_or(window.pos);
+                            window.pos = layout.tile_pos_in_workspace_view;
                             window.size = layout.tile_size;
                             // Update floating status
                             window.is_floating = layout.pos_in_scrolling_layout.is_none();

--- a/src/state/model.rs
+++ b/src/state/model.rs
@@ -88,7 +88,9 @@ impl MinimapState {
     /// - Removes workspaces not in `incoming` (their windows are dropped too).
     /// - Updates `idx`, `output`, `is_active` on existing workspaces.
     /// - Inserts new workspaces as empty.
-    /// - Updates `active_workspace_id` from whichever workspace has `is_focused`.
+    /// - Updates `active_workspace_id` to the incoming `is_focused` workspace.
+    ///   If none is focused, keeps the previous value when that workspace
+    ///   still exists, otherwise leaves it as `None`.
     pub fn replace_workspace_metadata(&mut self, incoming: &[niri_ipc::Workspace]) {
         use std::collections::HashSet;
 

--- a/src/state/model.rs
+++ b/src/state/model.rs
@@ -5,8 +5,11 @@ use std::collections::HashMap;
 pub struct Window {
     /// Unique window identifier from Niri
     pub id: u64,
-    /// Position in workspace view coordinates (x, y)
-    pub pos: (f64, f64),
+    /// Position in workspace view coordinates (x, y), if known. Niri only
+    /// populates `tile_pos_in_workspace_view` for windows whose tile is
+    /// currently positioned in the viewport; off-viewport windows arrive as
+    /// `None`. Don't treat `None` as `(0, 0)` — that destroys the distinction.
+    pub pos: Option<(f64, f64)>,
     /// Window tile size (width, height)
     pub size: (f64, f64),
     /// Column index in the scrolling layout
@@ -22,10 +25,19 @@ pub struct Window {
 /// Represents a workspace containing windows
 #[derive(Debug, Clone, Default)]
 pub struct Workspace {
+    /// Niri workspace id (stable across moves/reorder)
+    pub id: u64,
+    /// Index of the workspace on its monitor (display order)
+    pub idx: u8,
+    /// Name of the output this workspace is on, if any
+    pub output: Option<String>,
     /// Windows in this workspace, keyed by window ID
     pub windows: HashMap<u64, Window>,
     /// Whether this workspace is currently active
     pub is_active: bool,
+    /// The most-recently-focused window id on this workspace, if any. Niri
+    /// tracks this per workspace and uses it for Overview-style alignment.
+    pub active_window_id: Option<u64>,
 }
 
 impl Workspace {}
@@ -53,12 +65,61 @@ impl MinimapState {
             .and_then(|id| self.workspaces.get(&id))
     }
 
+    /// Workspaces sorted for display (by output, then idx).
+    ///
+    /// Workspaces without an output sort last; within the same output they
+    /// are ordered by `idx` ascending.
+    pub fn workspaces_sorted(&self) -> Vec<&Workspace> {
+        let mut out: Vec<&Workspace> = self.workspaces.values().collect();
+        out.sort_by(|a, b| {
+            a.output
+                .is_none()
+                .cmp(&b.output.is_none())
+                .then_with(|| a.output.cmp(&b.output))
+                .then_with(|| a.idx.cmp(&b.idx))
+                .then_with(|| a.id.cmp(&b.id))
+        });
+        out
+    }
+
+    /// Replace workspace metadata from a fresh snapshot, preserving existing
+    /// window data for workspaces that still exist.
+    ///
+    /// - Removes workspaces not in `incoming` (their windows are dropped too).
+    /// - Updates `idx`, `output`, `is_active` on existing workspaces.
+    /// - Inserts new workspaces as empty.
+    /// - Updates `active_workspace_id` from whichever workspace has `is_focused`.
+    pub fn replace_workspace_metadata(&mut self, incoming: &[niri_ipc::Workspace]) {
+        use std::collections::HashSet;
+
+        let incoming_ids: HashSet<u64> = incoming.iter().map(|w| w.id).collect();
+        self.workspaces.retain(|id, _| incoming_ids.contains(id));
+
+        for ws in incoming {
+            let entry = self.workspaces.entry(ws.id).or_insert_with(|| Workspace {
+                id: ws.id,
+                ..Default::default()
+            });
+            entry.id = ws.id;
+            entry.idx = ws.idx;
+            entry.output = ws.output.clone();
+            entry.is_active = ws.is_active;
+            entry.active_window_id = ws.active_window_id;
+        }
+
+        // Track the globally focused workspace (there is at most one).
+        self.active_workspace_id = incoming.iter().find(|w| w.is_focused).map(|w| w.id).or(self
+            .active_workspace_id
+            .filter(|id| incoming_ids.contains(id)));
+    }
+
     /// Update or insert a window in the appropriate workspace
     pub fn upsert_window(&mut self, workspace_id: u64, window: Window) {
         let workspace = self
             .workspaces
             .entry(workspace_id)
             .or_insert_with(|| Workspace {
+                id: workspace_id,
                 ..Default::default()
             });
         workspace.windows.insert(window.id, window);
@@ -108,6 +169,7 @@ impl MinimapState {
             .workspaces
             .entry(workspace_id)
             .or_insert_with(|| Workspace {
+                id: workspace_id,
                 ..Default::default()
             });
         workspace.is_active = true;
@@ -121,7 +183,7 @@ mod tests {
     fn create_test_window(id: u64, x: f64, y: f64, width: f64, height: f64) -> Window {
         Window {
             id,
-            pos: (x, y),
+            pos: Some((x, y)),
             size: (width, height),
             column_index: 0,
             window_index: 0,
@@ -162,7 +224,7 @@ mod tests {
         let workspace = state.workspaces.get(&1).unwrap();
         assert_eq!(workspace.windows.len(), 1);
         let window = workspace.windows.get(&1).unwrap();
-        assert_eq!(window.pos, (50.0, 50.0));
+        assert_eq!(window.pos, Some((50.0, 50.0)));
         assert_eq!(window.size, (150.0, 250.0));
     }
 
@@ -263,5 +325,94 @@ mod tests {
     fn test_minimap_state_active_workspace_none() {
         let state = MinimapState::new();
         assert!(state.active_workspace().is_none());
+    }
+
+    fn ipc_workspace(
+        id: u64,
+        idx: u8,
+        output: Option<&str>,
+        is_active: bool,
+        is_focused: bool,
+    ) -> niri_ipc::Workspace {
+        niri_ipc::Workspace {
+            id,
+            idx,
+            name: None,
+            output: output.map(|s| s.to_string()),
+            is_urgent: false,
+            is_active,
+            is_focused,
+            active_window_id: None,
+        }
+    }
+
+    #[test]
+    fn test_workspaces_sorted_by_output_then_idx() {
+        let mut state = MinimapState::new();
+        let incoming = vec![
+            ipc_workspace(3, 2, Some("DP-1"), false, false),
+            ipc_workspace(1, 1, Some("DP-1"), true, true),
+            ipc_workspace(5, 1, Some("HDMI-1"), true, false),
+            ipc_workspace(7, 99, None, false, false),
+            ipc_workspace(4, 3, Some("DP-1"), false, false),
+        ];
+        state.replace_workspace_metadata(&incoming);
+
+        let sorted_ids: Vec<u64> = state.workspaces_sorted().iter().map(|w| w.id).collect();
+        // DP-1: idx 1, 2, 3 -> 1, 3, 4; then HDMI-1 idx 1 -> 5; then no-output -> 7
+        assert_eq!(sorted_ids, vec![1, 3, 4, 5, 7]);
+    }
+
+    #[test]
+    fn test_replace_workspace_metadata_preserves_windows() {
+        let mut state = MinimapState::new();
+        let window = create_test_window(1, 0.0, 0.0, 100.0, 200.0);
+        state.upsert_window(1, window);
+
+        // Initial: workspace 1 exists with a window
+        assert_eq!(state.workspaces.get(&1).unwrap().windows.len(), 1);
+
+        // Metadata arrives claiming workspace 1 on DP-1, idx=0, focused
+        let incoming = vec![ipc_workspace(1, 0, Some("DP-1"), true, true)];
+        state.replace_workspace_metadata(&incoming);
+
+        let ws = state.workspaces.get(&1).unwrap();
+        assert_eq!(ws.idx, 0);
+        assert_eq!(ws.output.as_deref(), Some("DP-1"));
+        assert!(ws.is_active);
+        // Windows preserved
+        assert_eq!(ws.windows.len(), 1);
+        assert_eq!(state.active_workspace_id, Some(1));
+    }
+
+    #[test]
+    fn test_replace_workspace_metadata_removes_missing() {
+        let mut state = MinimapState::new();
+        state.upsert_window(1, create_test_window(10, 0.0, 0.0, 100.0, 200.0));
+        state.upsert_window(2, create_test_window(20, 0.0, 0.0, 100.0, 200.0));
+        state.active_workspace_id = Some(2);
+
+        // Only workspace 1 survives
+        let incoming = vec![ipc_workspace(1, 0, None, true, true)];
+        state.replace_workspace_metadata(&incoming);
+
+        assert!(state.workspaces.contains_key(&1));
+        assert!(!state.workspaces.contains_key(&2));
+        // Active workspace updated to the focused one
+        assert_eq!(state.active_workspace_id, Some(1));
+    }
+
+    #[test]
+    fn test_replace_workspace_metadata_inserts_new_empty() {
+        let mut state = MinimapState::new();
+        let incoming = vec![
+            ipc_workspace(1, 0, None, true, true),
+            ipc_workspace(2, 1, None, false, false),
+        ];
+        state.replace_workspace_metadata(&incoming);
+
+        assert_eq!(state.workspaces.len(), 2);
+        assert!(state.workspaces.get(&1).unwrap().windows.is_empty());
+        assert!(state.workspaces.get(&2).unwrap().windows.is_empty());
     }
 }

--- a/src/ui/layer.rs
+++ b/src/ui/layer.rs
@@ -15,6 +15,11 @@ pub fn create_layer_window(app: &Application, config: &Config) -> ApplicationWin
         .resizable(true) // Allow resizing for dynamic width
         .build();
 
+    // Tag the window with a CSS class so our transparency rules can target it
+    // with high specificity (themes commonly set `.background { ... !important }`,
+    // which beats `* { ... !important }` due to specificity).
+    window.add_css_class("nirimap-window");
+
     // Initialize layer shell
     window.init_layer_shell();
 
@@ -42,13 +47,34 @@ pub fn create_layer_window(app: &Application, config: &Config) -> ApplicationWin
     window.set_margin(Edge::Left, config.display.margin_x);
     window.set_margin(Edge::Right, config.display.margin_x);
 
-    // Set up CSS for transparency support
+    // Set up CSS for transparency. GTK renders widget CSS backgrounds in a
+    // separate render node beneath our Cairo content, so we must zero it out
+    // via CSS. Use high-specificity selectors targeting our own CSS class so
+    // theme rules (often `.background { ... !important }`, specificity 0,0,1,0)
+    // can't beat us. Combine class + tag for specificity 0,0,1,1.
     let css_provider = gtk4::CssProvider::new();
-    css_provider.load_from_data("window { background: transparent; }");
+    css_provider.connect_parsing_error(|_, section, error| {
+        tracing::error!(
+            "nirimap transparency CSS parse error at {:?}: {}",
+            section,
+            error
+        );
+    });
+    css_provider.load_from_data(
+        "window.nirimap-window,
+         window.nirimap-window.background,
+         window.nirimap-window > widget,
+         window.nirimap-window > drawingarea,
+         drawingarea.nirimap-canvas {
+             background-color: transparent;
+             background-image: none;
+             box-shadow: none;
+         }",
+    );
     gtk4::style_context_add_provider_for_display(
         &gtk4::gdk::Display::default().expect("Could not get default display"),
         &css_provider,
-        gtk4::STYLE_PROVIDER_PRIORITY_APPLICATION,
+        gtk4::STYLE_PROVIDER_PRIORITY_USER,
     );
 
     // Set up empty input region for true click-through at Wayland level

--- a/src/ui/minimap.rs
+++ b/src/ui/minimap.rs
@@ -1,4 +1,5 @@
 use std::cell::{Cell, RefCell};
+use std::collections::BTreeMap;
 use std::rc::Rc;
 
 use gtk4::cairo::{Context, Operator};
@@ -6,8 +7,11 @@ use gtk4::glib;
 use gtk4::prelude::*;
 use gtk4::{ApplicationWindow, DrawingArea};
 
-use crate::config::{AppearanceConfig, Color, Config};
-use crate::state::{MinimapState, Window};
+use crate::config::{AppearanceConfig, Color, Config, DisplayConfig, WorkspaceMode};
+use crate::state::{MinimapState, Window, Workspace};
+
+/// Outer padding around the minimap content, in minimap pixels.
+const PADDING: f64 = 4.0;
 
 /// Wrapper around DrawingArea for the minimap
 #[derive(Clone)]
@@ -25,6 +29,8 @@ impl MinimapWidget {
     /// Create a new minimap widget
     pub fn new(config: Rc<RefCell<Config>>) -> Self {
         let drawing_area = DrawingArea::new();
+        // Tag for the transparency CSS (see layer.rs).
+        drawing_area.add_css_class("nirimap-canvas");
         let state = Rc::new(RefCell::new(MinimapState::new()));
 
         // Start with just the height; width will be calculated
@@ -124,16 +130,8 @@ impl MinimapWidget {
     pub fn reload_config(&self) {
         match Config::load() {
             Ok(new_config) => {
-                let old_height = self.config.borrow().display.height;
-                let new_height = new_config.display.height;
-
                 // Update the config
                 *self.config.borrow_mut() = new_config;
-
-                // If height changed, update the drawing area
-                if old_height != new_height {
-                    self.drawing_area.set_content_height(new_height as i32);
-                }
 
                 // Trigger resize and redraw
                 self.update_size();
@@ -167,59 +165,47 @@ impl MinimapWidget {
         let state = self.state.borrow();
         let config = self.config.borrow();
 
-        let height = config.display.height as f64;
-        let padding = 4.0;
-        let inner_height = height - padding * 2.0;
+        let (max_width, max_height) = self.get_monitor_caps();
+        let viewport_width = monitor_logical_width();
+        let dims = compute_widget_dimensions(
+            &state,
+            &config.display,
+            config.appearance.workspace_gap,
+            max_width,
+            max_height,
+            viewport_width,
+        );
 
-        // Calculate workspace dimensions
-        let (total_width, max_height) = calculate_workspace_dimensions(&state);
+        let final_width = dims.width.ceil() as i32;
+        let final_height = dims.height.ceil() as i32;
 
-        if total_width <= 0.0 || max_height <= 0.0 {
-            // No windows, use minimum size
-            let min_width = height as i32;
-            self.drawing_area.set_content_width(min_width);
-            if let Some(window) = self.window.borrow().as_ref() {
-                window.set_default_width(min_width);
-            }
-            return;
-        }
-
-        // Calculate scale based on fitting workspace height into minimap height
-        let scale = inner_height / max_height;
-
-        // Calculate required width
-        let ideal_width = (total_width * scale + padding * 2.0).ceil();
-
-        // Get max width from monitor
-        let max_width = self.get_max_width();
-
-        // Clamp width
-        let final_width = ideal_width.min(max_width).max(height) as i32;
-
-        // Update drawing area and window size
         self.drawing_area.set_content_width(final_width);
+        self.drawing_area.set_content_height(final_height);
         if let Some(window) = self.window.borrow().as_ref() {
             window.set_default_width(final_width);
+            window.set_default_height(final_height);
         }
     }
 
-    /// Get the maximum allowed width based on monitor and config
-    fn get_max_width(&self) -> f64 {
-        let max_width_percent = self.config.borrow().display.max_width_percent;
+    /// Get monitor-based caps for widget width and height.
+    fn get_monitor_caps(&self) -> (f64, f64) {
+        let display_cfg = &self.config.borrow().display;
+        let max_width_percent = display_cfg.max_width_percent;
+        let max_height_percent = display_cfg.max_height_percent;
 
-        // Try to get monitor dimensions
         if let Some(display) = gtk4::gdk::Display::default() {
             if let Some(monitor) = display.monitors().item(0) {
                 if let Some(monitor) = monitor.downcast_ref::<gtk4::gdk::Monitor>() {
                     let geometry = monitor.geometry();
-                    let monitor_width = geometry.width() as f64;
-                    return monitor_width * max_width_percent;
+                    let w = geometry.width() as f64 * max_width_percent;
+                    let h = geometry.height() as f64 * max_height_percent;
+                    return (w, h);
                 }
             }
         }
 
-        // Fallback: use a reasonable default
-        1920.0 * max_width_percent
+        // Fallback: use a reasonable default (1920x1080 baseline)
+        (1920.0 * max_width_percent, 1080.0 * max_height_percent)
     }
 
     /// Set up the draw handler
@@ -229,54 +215,314 @@ impl MinimapWidget {
 
         self.drawing_area
             .set_draw_func(move |_area, cr, width, height| {
+                let cfg = config.borrow();
+                let viewport_width = monitor_logical_width();
                 draw_minimap(
                     cr,
                     width,
                     height,
                     &state.borrow(),
-                    &config.borrow().appearance,
+                    &cfg.display,
+                    &cfg.appearance,
+                    viewport_width,
                 );
             });
     }
 }
 
-/// Calculate total workspace dimensions from windows (excluding floating windows)
-fn calculate_workspace_dimensions(state: &MinimapState) -> (f64, f64) {
-    let Some(workspace) = state.active_workspace() else {
-        return (0.0, 0.0);
-    };
-
-    if workspace.windows.is_empty() {
-        return (0.0, 0.0);
+/// Monitor's logical width — used as the workspace viewport width.
+///
+/// Niri's per-workspace viewport equals its output's logical width. We don't
+/// query niri-ipc for output info today, so we use the GTK display's monitor
+/// geometry, which matches for the single-output case (the only setup nirimap
+/// currently supports — see "Known limitations" in the README).
+fn monitor_logical_width() -> f64 {
+    if let Some(display) = gtk4::gdk::Display::default() {
+        if let Some(monitor) = display.monitors().item(0) {
+            if let Some(monitor) = monitor.downcast_ref::<gtk4::gdk::Monitor>() {
+                return monitor.geometry().width() as f64;
+            }
+        }
     }
+    1920.0
+}
 
-    // Group windows by column, excluding floating windows
-    let mut columns: std::collections::BTreeMap<usize, Vec<&Window>> =
-        std::collections::BTreeMap::new();
+/// Per-workspace geometry computed from its tiled windows.
+struct WorkspaceLayout<'a> {
+    workspace: &'a Workspace,
+    /// Tiled windows grouped by column, sorted by window_index.
+    columns: BTreeMap<usize, Vec<&'a Window>>,
+    /// X position of each column in scrolling-layout (workspace) coords.
+    column_x_positions: Vec<f64>,
+    /// Total width of the scrolling layout.
+    total_width: f64,
+    /// Max column height across the workspace.
+    max_height: f64,
+    /// Workspace-x of this workspace's alignment column — the column that
+    /// should land at the shared screen anchor. Derived from the workspace's
+    /// `active_window_id` (the most-recently-focused window on that workspace,
+    /// which Niri tracks per-workspace and uses for Overview-style alignment).
+    /// Falls back to 0 when no active window is tracked.
+    align_x: f64,
+    /// Left extent in anchored coords: `-align_x` (col 0's anchored position).
+    anchored_left: f64,
+    /// Right extent in anchored coords: `total_width - align_x`.
+    anchored_right: f64,
+    /// Whether this workspace has any tiled windows.
+    has_tiled: bool,
+}
+
+/// Select the workspaces that should appear in `all` mode:
+/// any workspace that has at least one window, plus the focused one even if empty.
+/// This filters out Niri's trailing placeholder workspace (the always-present empty
+/// workspace users can scroll into to create a new one) unless the user is on it.
+fn all_mode_rows(state: &MinimapState, viewport_width: f64) -> Vec<WorkspaceLayout<'_>> {
+    let active_id = state.active_workspace_id;
+    state
+        .workspaces_sorted()
+        .into_iter()
+        .filter(|ws| !ws.windows.is_empty() || Some(ws.id) == active_id)
+        .map(|ws| build_workspace_layout(ws, viewport_width))
+        .collect()
+}
+
+/// Build the layout for a single workspace (tiled windows only).
+fn build_workspace_layout(workspace: &Workspace, viewport_width: f64) -> WorkspaceLayout<'_> {
+    let mut columns: BTreeMap<usize, Vec<&Window>> = BTreeMap::new();
     for window in workspace.windows.values() {
         if !window.is_floating {
             columns.entry(window.column_index).or_default().push(window);
         }
     }
-
-    if columns.is_empty() {
-        return (0.0, 0.0);
+    for windows in columns.values_mut() {
+        windows.sort_by_key(|w| w.window_index);
     }
 
-    // Calculate dimensions
-    let mut total_width = 0.0f64;
-    let mut max_height = 0.0f64;
-
-    for col_idx in 0..=columns.keys().max().copied().unwrap_or(0) {
-        if let Some(windows) = columns.get(&col_idx) {
-            let col_width = windows.iter().map(|w| w.size.0).fold(0.0f64, f64::max);
-            let col_height: f64 = windows.iter().map(|w| w.size.1).sum();
-            total_width += col_width;
-            max_height = max_height.max(col_height);
+    let mut column_widths: Vec<f64> = Vec::new();
+    let mut column_heights: Vec<f64> = Vec::new();
+    if let Some(&max_col) = columns.keys().max() {
+        for col_idx in 0..=max_col {
+            if let Some(windows) = columns.get(&col_idx) {
+                let w = windows.iter().map(|w| w.size.0).fold(0.0_f64, f64::max);
+                let h: f64 = windows.iter().map(|w| w.size.1).sum();
+                column_widths.push(w);
+                column_heights.push(h);
+            } else {
+                column_widths.push(0.0);
+                column_heights.push(0.0);
+            }
         }
     }
 
-    (total_width, max_height)
+    let mut column_x_positions = Vec::with_capacity(column_widths.len());
+    let mut x = 0.0_f64;
+    for &w in &column_widths {
+        column_x_positions.push(x);
+        x += w;
+    }
+    let total_width: f64 = column_widths.iter().sum();
+    let max_height = column_heights.iter().fold(0.0_f64, |a, &b| a.max(b));
+
+    // Derive the viewport offset (`align_x`) — the workspace-x of the
+    // viewport's left edge.
+    //
+    // Niri populates `tile_pos_in_workspace_view` for tiles in the active
+    // workspace's viewport. When present we derive the real offset as
+    // `column_x - pos.x` from any such tile so the minimap mirrors niri's
+    // actual viewport, including the case where a sub-viewport-width column
+    // is positioned past the viewport's left edge (a negative offset — e.g.
+    // when niri right-aligns a shrunk window within the viewport).
+    //
+    // Without `pos` (background workspaces): if content fits in the viewport
+    // niri pins it at 0; otherwise we approximate using the last-focused
+    // window's column position, clamped to `[0, total_width - viewport_width]`
+    // so right-edge content stays right-aligned.
+    let pos_offset = workspace
+        .windows
+        .values()
+        .filter(|w| !w.is_floating)
+        .find_map(|w| {
+            let (px, _) = w.pos?;
+            let col_x = column_x_positions.get(w.column_index).copied()?;
+            Some(col_x - px)
+        });
+    let align_x = if let Some(offset) = pos_offset {
+        offset
+    } else if total_width <= viewport_width {
+        0.0
+    } else {
+        let max_offset = total_width - viewport_width;
+        workspace
+            .active_window_id
+            .and_then(|id| workspace.windows.get(&id))
+            .filter(|w| !w.is_floating)
+            .and_then(|w| column_x_positions.get(w.column_index).copied())
+            .unwrap_or(0.0)
+            .clamp(0.0, max_offset)
+    };
+
+    let has_tiled = !columns.is_empty();
+    let anchored_left = -align_x;
+    let anchored_right = total_width - align_x;
+
+    WorkspaceLayout {
+        workspace,
+        columns,
+        column_x_positions,
+        total_width,
+        max_height,
+        align_x,
+        anchored_left,
+        anchored_right,
+        has_tiled,
+    }
+}
+
+/// Resolved widget dimensions.
+struct WidgetDimensions {
+    width: f64,
+    height: f64,
+}
+
+/// Geometry shared across all workspace rows in `all` mode.
+///
+/// All rows use the same scale so viewports align visually. Each row is drawn
+/// from its own `row_x_origin` (the screen x where its workspace-coord 0 sits),
+/// which is computed from the shared `viewport_anchor_x` and the workspace's
+/// `viewport_offset`.
+struct AllModeGeometry {
+    widget_width: f64,
+    widget_height: f64,
+    row_height: f64,
+    scale: f64,
+    /// Screen x where the anchored frame's origin (viewport left edge) lives.
+    viewport_anchor_x: f64,
+}
+
+/// Compute shared all-mode geometry from the workspace rows and config caps.
+fn compute_all_mode_geometry(
+    rows: &[WorkspaceLayout<'_>],
+    display: &DisplayConfig,
+    workspace_gap: f64,
+    max_width: f64,
+    max_height: f64,
+) -> AllModeGeometry {
+    let row_height_cfg = display.height as f64;
+    let min_widget_width = row_height_cfg;
+
+    let n = rows.len().max(1) as f64;
+    let total_gap = (n - 1.0).max(0.0) * workspace_gap;
+
+    let ideal_height = n * row_height_cfg + total_gap + PADDING * 2.0;
+    let min_height = row_height_cfg + PADDING * 2.0;
+    let widget_height = ideal_height.min(max_height.max(min_height)).max(min_height);
+
+    let available = widget_height - PADDING * 2.0 - total_gap;
+    let row_height = (available / n).max(1.0);
+
+    // Shared scale: fit the tallest workspace's column height into row_height.
+    let global_max_height = rows
+        .iter()
+        .filter(|l| l.has_tiled)
+        .map(|l| l.max_height)
+        .fold(0.0_f64, f64::max);
+    let scale = if global_max_height > 0.0 {
+        row_height / global_max_height
+    } else {
+        0.0
+    };
+
+    // Content extents in the anchored (viewport-relative) frame across all
+    // rows. Each workspace contributes `[-viewport_offset, total_width - viewport_offset]`.
+    let combined_left = rows
+        .iter()
+        .filter(|l| l.has_tiled)
+        .map(|l| l.anchored_left)
+        .fold(f64::INFINITY, f64::min);
+    let combined_right = rows
+        .iter()
+        .filter(|l| l.has_tiled)
+        .map(|l| l.anchored_right)
+        .fold(f64::NEG_INFINITY, f64::max);
+    let has_content = combined_left.is_finite() && combined_right.is_finite();
+
+    let (scaled_content_width, viewport_anchor_x) = if has_content {
+        let w = (combined_right - combined_left) * scale;
+        // Place the leftmost anchored content at x = PADDING; then anchored x=0
+        // (each workspace's viewport left edge) lives at:
+        let anchor = PADDING - combined_left * scale;
+        (w, anchor)
+    } else {
+        (0.0, PADDING)
+    };
+
+    let ideal_width = scaled_content_width + PADDING * 2.0;
+    let widget_width = ideal_width.min(max_width).max(min_widget_width);
+
+    AllModeGeometry {
+        widget_width,
+        widget_height,
+        row_height,
+        scale,
+        viewport_anchor_x,
+    }
+}
+
+/// Compute widget dimensions based on state and config.
+fn compute_widget_dimensions(
+    state: &MinimapState,
+    display: &DisplayConfig,
+    workspace_gap: f64,
+    max_width: f64,
+    max_height: f64,
+    viewport_width: f64,
+) -> WidgetDimensions {
+    let row_height_cfg = display.height as f64;
+    let min_widget_width = row_height_cfg;
+
+    match display.workspace_mode {
+        WorkspaceMode::Current => {
+            let widget_height = row_height_cfg;
+            let row_height = (widget_height - PADDING * 2.0).max(0.0);
+            let scaled_w = state
+                .active_workspace()
+                .map(|ws| {
+                    row_scaled_width_centered(
+                        &build_workspace_layout(ws, viewport_width),
+                        row_height,
+                    )
+                })
+                .unwrap_or(0.0);
+
+            let ideal_width = scaled_w + PADDING * 2.0;
+            let width = ideal_width.min(max_width).max(min_widget_width);
+
+            WidgetDimensions {
+                width,
+                height: widget_height,
+            }
+        }
+        WorkspaceMode::All => {
+            let rows = all_mode_rows(state, viewport_width);
+            let geom =
+                compute_all_mode_geometry(&rows, display, workspace_gap, max_width, max_height);
+
+            WidgetDimensions {
+                width: geom.widget_width,
+                height: geom.widget_height,
+            }
+        }
+    }
+}
+
+/// Compute the scaled width a workspace row would occupy at the given inner row height
+/// when rendered with column-centered layout ("current" mode).
+fn row_scaled_width_centered(layout: &WorkspaceLayout<'_>, row_inner_height: f64) -> f64 {
+    if layout.total_width <= 0.0 || layout.max_height <= 0.0 || row_inner_height <= 0.0 {
+        return 0.0;
+    }
+    let scale = row_inner_height / layout.max_height;
+    layout.total_width * scale
 }
 
 /// Draw the minimap
@@ -285,7 +531,9 @@ fn draw_minimap(
     width: i32,
     height: i32,
     state: &MinimapState,
+    display: &DisplayConfig,
     appearance: &AppearanceConfig,
+    viewport_width: f64,
 ) {
     let width = width as f64;
     let height = height as f64;
@@ -295,7 +543,7 @@ fn draw_minimap(
     cr.paint().ok();
     cr.set_operator(Operator::Over);
 
-    // Draw background (only if opacity > 0)
+    // Optional background fill — applied in both modes; transparent by default.
     if appearance.background_opacity > 0.0 {
         if let Some(bg_color) = Color::from_hex(&appearance.background) {
             cr.set_source_rgba(
@@ -309,77 +557,116 @@ fn draw_minimap(
         }
     }
 
-    // Get the active workspace
-    let Some(workspace) = state.active_workspace() else {
-        return;
-    };
+    let inner_width = (width - PADDING * 2.0).max(0.0);
 
-    if workspace.windows.is_empty() {
-        return;
-    }
+    match display.workspace_mode {
+        WorkspaceMode::Current => {
+            let Some(workspace) = state.active_workspace() else {
+                return;
+            };
+            let layout = build_workspace_layout(workspace, viewport_width);
+            if layout.total_width <= 0.0 || layout.max_height <= 0.0 {
+                return;
+            }
+            let row_inner_height = (height - PADDING * 2.0).max(0.0);
+            draw_workspace_row_centered(
+                cr,
+                &layout,
+                PADDING,
+                PADDING,
+                inner_width,
+                row_inner_height,
+                appearance,
+            );
+        }
+        WorkspaceMode::All => {
+            let rows = all_mode_rows(state, viewport_width);
+            if rows.is_empty() {
+                return;
+            }
 
-    // Separate tiled and floating windows
-    // Note: floating_windows is not currently implemented for minimap, see comments below.
-    let mut tiled_windows: Vec<&Window> = Vec::new();
-    let mut floating_windows: Vec<&Window> = Vec::new();
+            // Recompute the shared geometry using this draw call's actual widget size.
+            // max_height is effectively the current height — we use the drawing area's
+            // reported height as both the ideal and the cap to stay consistent with
+            // what was set by update_size().
+            let geom =
+                compute_all_mode_geometry(&rows, display, appearance.workspace_gap, width, height);
 
-    for window in workspace.windows.values() {
-        if window.is_floating {
-            floating_windows.push(window);
-        } else {
-            tiled_windows.push(window);
+            let active_border = Color::from_hex(&appearance.active_workspace_border_color)
+                .unwrap_or(Color {
+                    r: 0.54,
+                    g: 0.71,
+                    b: 0.98,
+                    a: 1.0,
+                });
+
+            let mut y = PADDING;
+            for layout in &rows {
+                // Active workspace highlight: border around the row rectangle.
+                if layout.workspace.is_active && appearance.active_workspace_border_width > 0.0 {
+                    cr.set_source_rgba(
+                        active_border.r,
+                        active_border.g,
+                        active_border.b,
+                        active_border.a,
+                    );
+                    cr.set_line_width(appearance.active_workspace_border_width);
+                    let inset = appearance.active_workspace_border_width / 2.0;
+                    rounded_rectangle(
+                        cr,
+                        PADDING + inset,
+                        y + inset,
+                        (inner_width - inset * 2.0).max(0.0),
+                        (geom.row_height - inset * 2.0).max(0.0),
+                        appearance.border_radius,
+                    );
+                    cr.stroke().ok();
+                }
+
+                if layout.has_tiled && geom.scale > 0.0 {
+                    draw_workspace_row_viewport(
+                        cr,
+                        layout,
+                        PADDING,
+                        y,
+                        inner_width,
+                        geom.row_height,
+                        geom.scale,
+                        geom.viewport_anchor_x,
+                        appearance,
+                    );
+                }
+
+                y += geom.row_height + appearance.workspace_gap;
+            }
         }
     }
+}
 
-    // Group tiled windows by column and sort by window_index within each column
-    let mut columns: std::collections::BTreeMap<usize, Vec<&Window>> =
-        std::collections::BTreeMap::new();
-    for window in tiled_windows {
-        columns.entry(window.column_index).or_default().push(window);
-    }
-
-    // Sort windows within each column by their window_index
-    for windows in columns.values_mut() {
-        windows.sort_by_key(|w| w.window_index);
-    }
-
-    // Calculate column positions and total dimensions
-    let mut column_widths: Vec<f64> = Vec::new();
-    let mut column_heights: Vec<f64> = Vec::new();
-
-    for col_idx in 0..=columns.keys().max().copied().unwrap_or(0) {
-        if let Some(windows) = columns.get(&col_idx) {
-            let max_width = windows.iter().map(|w| w.size.0).fold(0.0f64, f64::max);
-            let total_height: f64 = windows.iter().map(|w| w.size.1).sum();
-            column_widths.push(max_width);
-            column_heights.push(total_height);
-        } else {
-            column_widths.push(0.0);
-            column_heights.push(0.0);
-        }
-    }
-
-    let total_width: f64 = column_widths.iter().sum();
-    let max_height: f64 = column_heights.iter().fold(0.0f64, |a, &b| a.max(b));
-
-    if total_width <= 0.0 || max_height <= 0.0 {
+/// Draw all tiled windows of one workspace into the rectangle
+/// `(offset_x, offset_y, row_width, row_height)` using column-based centered layout.
+///
+/// Used for `current` mode: windows are grouped by column and laid out as a single
+/// scrolling-layout image, horizontally centered in the row.
+fn draw_workspace_row_centered(
+    cr: &Context,
+    layout: &WorkspaceLayout<'_>,
+    offset_x: f64,
+    offset_y: f64,
+    row_width: f64,
+    row_height: f64,
+    appearance: &AppearanceConfig,
+) {
+    if layout.total_width <= 0.0 || layout.max_height <= 0.0 || row_height <= 0.0 {
         return;
     }
 
-    // Add padding inside the minimap
-    let padding = 4.0;
-    let inner_width = width - padding * 2.0;
-    let inner_height = height - padding * 2.0;
+    // Scale to fit height; horizontally center within the row.
+    let scale = row_height / layout.max_height;
+    let scaled_width = layout.total_width * scale;
+    let x_origin = offset_x + (row_width - scaled_width).max(0.0) / 2.0;
+    let y_origin = offset_y;
 
-    // Scale based on height (width is dynamic, so we primarily fit height)
-    let scale = inner_height / max_height;
-
-    // Calculate offset - center vertically, left-align horizontally
-    let scaled_width = total_width * scale;
-    let offset_x = padding + (inner_width - scaled_width).max(0.0) / 2.0;
-    let offset_y = padding;
-
-    // Get colors
     let window_color = Color::from_hex(&appearance.window_color).unwrap_or(Color {
         r: 0.27,
         g: 0.28,
@@ -402,52 +689,44 @@ fn draw_minimap(
     let gap = appearance.gap;
     let half_gap = gap / 2.0;
 
-    // Calculate x position for each column
-    let mut column_x_positions: Vec<f64> = Vec::new();
-    let mut x_pos = 0.0;
-    for &col_width in &column_widths {
-        column_x_positions.push(x_pos);
-        x_pos += col_width;
-    }
-
-    // Draw each window
-    for (&col_idx, windows) in &columns {
-        let col_x = column_x_positions.get(col_idx).copied().unwrap_or(0.0);
+    for (&col_idx, windows) in &layout.columns {
+        let col_x = layout
+            .column_x_positions
+            .get(col_idx)
+            .copied()
+            .unwrap_or(0.0);
         let mut y_pos = 0.0;
 
         for window in windows {
-            // Transform coordinates
-            let x = offset_x + col_x * scale;
-            let y = offset_y + y_pos * scale;
+            let x = x_origin + col_x * scale;
+            let y = y_origin + y_pos * scale;
             let w = window.size.0 * scale;
             let h = window.size.1 * scale;
 
             y_pos += window.size.1;
 
-            // Apply gap (shrink window by half_gap on each side)
+            // Apply gap
             let x = x + half_gap;
             let y = y + half_gap;
             let w = (w - gap).max(1.0);
             let h = (h - gap).max(1.0);
 
-            // Skip windows that are too small to render
             if w < 1.0 || h < 1.0 {
                 continue;
             }
 
-            // Choose fill color based on focus state
-            let fill_color = if window.is_focused {
-                &focused_color
+            let (fill_color, fill_alpha) = if window.is_focused {
+                (&focused_color, appearance.focused_opacity)
             } else {
-                &window_color
+                (&window_color, appearance.window_opacity)
             };
 
-            // Draw the window rectangle fill
-            cr.set_source_rgba(fill_color.r, fill_color.g, fill_color.b, fill_color.a);
-            rounded_rectangle(cr, x, y, w, h, appearance.border_radius);
-            cr.fill().ok();
+            if fill_alpha > 0.0 {
+                cr.set_source_rgba(fill_color.r, fill_color.g, fill_color.b, fill_alpha);
+                rounded_rectangle(cr, x, y, w, h, appearance.border_radius);
+                cr.fill().ok();
+            }
 
-            // Draw border on all windows
             if appearance.border_width > 0.0 {
                 cr.set_source_rgba(
                     border_color.r,
@@ -462,102 +741,121 @@ fn draw_minimap(
         }
     }
 
-    // ==================================================================================
-    // FLOATING WINDOW RENDERING - CURRENTLY DISABLED
-    // ==================================================================================
-    // Floating windows are not rendered due to viewport offset tracking limitations.
-    // See GitHub Issue #6 for details: https://github.com/alexandergknoll/nirimap/issues/6
-    //
-    // The code below implements partial floating window support that works when:
-    // - A tiled window has focus (can estimate viewport offset from focused column)
-    // - Using left-align behavior (center-focused-column "never" in Niri config)
-    //
-    // Known issues that prevent enabling this:
-    // 1. When a floating window has focus, viewport offset cannot be determined
-    // 2. Viewport can scroll without focus changes (center-column, vertical stacking)
-    // 3. Assumes specific Niri configuration (center-focused-column "never")
-    //
-    // This code is preserved for future use when Niri's IPC exposes viewport position.
-    // ==================================================================================
+    // Floating windows intentionally not drawn here: see comment in git history
+    // and issue #6 — viewport offset is not exposed by Niri IPC, so floating
+    // window placement on the minimap is unreliable.
+}
 
-    /* DISABLED - Floating window rendering
+/// Draw all tiled windows of one workspace using viewport-anchored column layout.
+///
+/// Used for `all` mode. Columns are placed in scrolling-layout coordinates,
+/// then shifted by the workspace's own `viewport_offset` so that the workspace
+/// viewport (workspace-x = viewport_offset) lands at the shared
+/// `viewport_anchor_x`. Different workspaces with different viewport offsets
+/// therefore shift horizontally relative to each other (Overview-style).
+/// The drawing is clipped to the row's bounds so content outside the row
+/// doesn't leak into neighbouring rows.
+#[allow(clippy::too_many_arguments)]
+fn draw_workspace_row_viewport(
+    cr: &Context,
+    layout: &WorkspaceLayout<'_>,
+    offset_x: f64,
+    offset_y: f64,
+    row_width: f64,
+    row_height: f64,
+    scale: f64,
+    viewport_anchor_x: f64,
+    appearance: &AppearanceConfig,
+) {
+    if !layout.has_tiled || scale <= 0.0 || row_width <= 0.0 || row_height <= 0.0 {
+        return;
+    }
 
-    // Estimate viewport offset based on focused column (assumes left-align behavior)
-    let viewport_offset = if !columns.is_empty() {
-        // Find which column is focused (tiled windows only)
-        let focused_col = workspace.windows.values()
-            .find(|w| w.is_focused && !w.is_floating)
-            .map(|w| w.column_index);
+    let window_color = Color::from_hex(&appearance.window_color).unwrap_or(Color {
+        r: 0.27,
+        g: 0.28,
+        b: 0.35,
+        a: 1.0,
+    });
+    let focused_color = Color::from_hex(&appearance.focused_color).unwrap_or(Color {
+        r: 0.54,
+        g: 0.71,
+        b: 0.98,
+        a: 1.0,
+    });
+    let border_color = Color::from_hex(&appearance.border_color).unwrap_or(Color {
+        r: 0.42,
+        g: 0.44,
+        b: 0.53,
+        a: 1.0,
+    });
 
-        if let Some(focused_col_idx) = focused_col {
-            // With left-align (center-focused-column "never"), the focused column
-            // is positioned at the left edge of the viewport
-            // So viewport_offset = x position of the focused column
-            let offset = column_x_positions.get(focused_col_idx).copied().unwrap_or(0.0);
+    let gap = appearance.gap;
+    let half_gap = gap / 2.0;
 
-            tracing::debug!("Focused column: {}, Viewport offset (left-align): {}", focused_col_idx, offset);
+    // Screen x where this workspace's column at workspace-x = 0 sits.
+    // Equivalent to `viewport_anchor_x + anchored_left * scale`.
+    let row_x_origin = viewport_anchor_x - layout.align_x * scale;
+    let y_origin = offset_y;
 
-            offset
-        } else {
-            // No tiled window focused (floating window is focused)
-            // We can't determine viewport offset, so assume it hasn't changed
-            // This is a limitation - we'd need to track the last known offset
-            tracing::debug!("No tiled window focused (floating focused), using offset: 0");
-            0.0
-        }
-    } else {
-        0.0
-    };
+    // Clip to the row rect so off-viewport content doesn't leak into
+    // adjacent workspace rows or outside the widget.
+    cr.save().ok();
+    cr.rectangle(offset_x, offset_y, row_width, row_height);
+    cr.clip();
 
-    for window in floating_windows {
-        // Floating windows in Niri are already viewport-relative (like tiled windows)
-        // Their position is screen-relative, so we need to ADD the viewport offset
-        // to convert to workspace coordinates for rendering on the minimap
-        let workspace_x = window.pos.0 + viewport_offset;
-        let workspace_y = window.pos.1;
+    for (&col_idx, windows) in &layout.columns {
+        let col_x = layout
+            .column_x_positions
+            .get(col_idx)
+            .copied()
+            .unwrap_or(0.0);
+        let mut y_pos = 0.0;
 
-        tracing::debug!("Drawing floating window {}: viewport_pos=({}, {}), viewport_offset={}, workspace_pos=({}, {})",
-            window.id, window.pos.0, window.pos.1, viewport_offset, workspace_x, workspace_y);
+        for window in windows {
+            let x = row_x_origin + col_x * scale;
+            let y = y_origin + y_pos * scale;
+            let w = window.size.0 * scale;
+            let h = window.size.1 * scale;
 
-        // Transform to minimap coordinates
-        let x = offset_x + workspace_x * scale;
-        let y = offset_y + workspace_y * scale;
-        let w = window.size.0 * scale;
-        let h = window.size.1 * scale;
+            y_pos += window.size.1;
 
-        // Apply gap
-        let x = x + half_gap;
-        let y = y + half_gap;
-        let w = (w - gap).max(1.0);
-        let h = (h - gap).max(1.0);
+            let x = x + half_gap;
+            let y = y + half_gap;
+            let w = (w - gap).max(1.0);
+            let h = (h - gap).max(1.0);
 
-        // Skip windows that are too small to render
-        if w < 1.0 || h < 1.0 {
-            continue;
-        }
+            if w < 1.0 || h < 1.0 {
+                continue;
+            }
 
-        // Choose fill color based on focus state
-        let fill_color = if window.is_focused {
-            &focused_color
-        } else {
-            &window_color
-        };
+            let (fill_color, fill_alpha) = if window.is_focused {
+                (&focused_color, appearance.focused_opacity)
+            } else {
+                (&window_color, appearance.window_opacity)
+            };
 
-        // Draw the window rectangle fill
-        cr.set_source_rgba(fill_color.r, fill_color.g, fill_color.b, fill_color.a);
-        rounded_rectangle(cr, x, y, w, h, appearance.border_radius);
-        cr.fill().ok();
+            if fill_alpha > 0.0 {
+                cr.set_source_rgba(fill_color.r, fill_color.g, fill_color.b, fill_alpha);
+                rounded_rectangle(cr, x, y, w, h, appearance.border_radius);
+                cr.fill().ok();
+            }
 
-        // Draw border
-        if appearance.border_width > 0.0 {
-            cr.set_source_rgba(border_color.r, border_color.g, border_color.b, border_color.a);
-            cr.set_line_width(appearance.border_width);
-            rounded_rectangle(cr, x, y, w, h, appearance.border_radius);
-            cr.stroke().ok();
+            if appearance.border_width > 0.0 {
+                cr.set_source_rgba(
+                    border_color.r,
+                    border_color.g,
+                    border_color.b,
+                    border_color.a,
+                );
+                cr.set_line_width(appearance.border_width);
+                rounded_rectangle(cr, x, y, w, h, appearance.border_radius);
+                cr.stroke().ok();
+            }
         }
     }
 
-    */ // END DISABLED floating window rendering
+    cr.restore().ok();
 }
 
 /// Draw a rounded rectangle path

--- a/src/ui/minimap.rs
+++ b/src/ui/minimap.rs
@@ -406,6 +406,7 @@ fn compute_all_mode_geometry(
     workspace_gap: f64,
     max_width: f64,
     max_height: f64,
+    viewport_width: f64,
 ) -> AllModeGeometry {
     let row_height_cfg = display.height as f64;
     let min_widget_width = row_height_cfg;
@@ -446,7 +447,7 @@ fn compute_all_mode_geometry(
         .fold(f64::NEG_INFINITY, f64::max);
     let has_content = combined_left.is_finite() && combined_right.is_finite();
 
-    let (scaled_content_width, viewport_anchor_x) = if has_content {
+    let (scaled_content_width, ideal_anchor) = if has_content {
         let w = (combined_right - combined_left) * scale;
         // Place the leftmost anchored content at x = PADDING; then anchored x=0
         // (each workspace's viewport left edge) lives at:
@@ -458,6 +459,20 @@ fn compute_all_mode_geometry(
 
     let ideal_width = scaled_content_width + PADDING * 2.0;
     let widget_width = ideal_width.min(max_width).max(min_widget_width);
+
+    // If content fits, keep the leftmost-anchored layout. If we got clamped
+    // narrower, shifting `viewport_anchor_x` keeps the leftmost extent at
+    // PADDING but pushes content past the right edge — and a workspace with a
+    // large left-side off-viewport context (large `align_x`) can drag every
+    // workspace's viewport off the visible widget. Re-center on the viewport
+    // (anchored x in [0, viewport_width]) instead so it's always visible.
+    let inner_width = (widget_width - PADDING * 2.0).max(0.0);
+    let viewport_anchor_x = if !has_content || scaled_content_width <= inner_width {
+        ideal_anchor
+    } else {
+        let viewport_scaled = viewport_width * scale;
+        PADDING + (inner_width - viewport_scaled) / 2.0
+    };
 
     AllModeGeometry {
         widget_width,
@@ -504,8 +519,14 @@ fn compute_widget_dimensions(
         }
         WorkspaceMode::All => {
             let rows = all_mode_rows(state, viewport_width);
-            let geom =
-                compute_all_mode_geometry(&rows, display, workspace_gap, max_width, max_height);
+            let geom = compute_all_mode_geometry(
+                &rows,
+                display,
+                workspace_gap,
+                max_width,
+                max_height,
+                viewport_width,
+            );
 
             WidgetDimensions {
                 width: geom.widget_width,
@@ -589,8 +610,14 @@ fn draw_minimap(
             // max_height is effectively the current height — we use the drawing area's
             // reported height as both the ideal and the cap to stay consistent with
             // what was set by update_size().
-            let geom =
-                compute_all_mode_geometry(&rows, display, appearance.workspace_gap, width, height);
+            let geom = compute_all_mode_geometry(
+                &rows,
+                display,
+                appearance.workspace_gap,
+                width,
+                height,
+                viewport_width,
+            );
 
             let active_border = Color::from_hex(&appearance.active_workspace_border_color)
                 .unwrap_or(Color {


### PR DESCRIPTION
## Summary
- Adds an `all` workspace mode that renders every workspace stacked vertically with viewport-anchored alignment, mirroring Niri's Overview. Existing single-workspace behavior is preserved as the `current` mode.
- Tracks per-workspace metadata (id, idx, output, active_window_id) and consumes new niri events (`WorkspacesChanged`, `WorkspaceActiveWindowChanged`) to keep alignment correct as focus and layout change.
- New appearance options: per-workspace gap, active-workspace border highlight, separate window/focused fill opacities. Default `background_opacity` lowered to 0 so the minimap blends with the desktop by default.
- Hardens transparency CSS against theme rules that override `window` background with `!important`, by tagging the layer window with a class and using a higher-specificity selector.
- When `all`-mode content is wider than the `max_width_percent` cap, re-centers on each workspace's viewport so the focused area stays visible instead of being pushed off the right edge.

## Test plan
- [x] Set `workspace_mode = "all"` and confirm every non-empty workspace renders as a row, with the active one highlighted.
- [x] Switch workspaces; confirm the highlight follows focus and rows reorder when workspaces are reordered in Niri.
- [x] Scroll the active workspace horizontally and confirm the rendered viewport tracks Niri's actual viewport (works both for the active workspace and background workspaces with cached `active_window_id`).
- [x] Configure many workspaces with wide scrolling layouts so the minimap hits `max_width_percent`; confirm each viewport stays visible (no off-screen viewports).
- [x] Set `workspace_mode = "current"` and confirm classic single-workspace rendering still works, including dynamic width.
- [x] Toggle `background_opacity`, `window_opacity`, `focused_opacity`, `workspace_gap`, `active_workspace_border_*` and confirm hot reload applies them.
- [x] Run on a desktop with a theme that sets `window { background: ... !important }` and confirm the minimap stays transparent.
- [x] `cargo test`, `cargo clippy --all-targets`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)