### PR TITLE
Suppress minimap shows for floating-window activity (#24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,14 @@ active_workspace_border_color = "#89b4fa"   # Highlight border for the active wo
 active_workspace_border_width = 2           # Highlight border thickness ("all" mode)
 
 [behavior]
-show_on_overview = true     # Keep visible in Niri overview mode (not yet implemented)
-always_visible = true       # Always show minimap (false = only on events)
-hide_timeout_ms = 2000      # Milliseconds before hiding after an event
+show_on_overview = true        # Keep visible in Niri overview mode (not yet implemented)
+always_visible = true          # Always show minimap (false = only on events)
+hide_timeout_ms = 2000         # Milliseconds before hiding after an event
+show_for_floating_windows = false # Surface the minimap for floating-window events
+                                  # (focus to/from a floating window, floating window
+                                  # spawn). Off by default — floating windows aren't
+                                  # drawn on the minimap, so popup activity would
+                                  # otherwise flash it on/off.
 ```
 
 ### Workspace Display Modes
@@ -126,6 +131,16 @@ When `always_visible = false`, the minimap will show temporarily when:
 - Window layouts change (resize, move between columns)
 
 The minimap hides automatically after `hide_timeout_ms` milliseconds.
+
+By default, the minimap stays hidden for floating-window activity:
+
+- Focus moving **to** a floating window (popup, dialog, file picker)
+- Focus returning **from** a floating window to the previously-focused tile
+- A new floating window being spawned
+
+Floating windows aren't drawn on the minimap, so this activity would
+otherwise cause a distracting on/off flash. Set
+`show_for_floating_windows = true` to restore the prior behavior.
 
 ## Known Limitations
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -124,6 +124,11 @@ pub struct BehaviorConfig {
     pub always_visible: bool,
     /// Milliseconds to keep minimap visible after focus change (only when always_visible is false)
     pub hide_timeout_ms: u32,
+    /// Whether floating-window events (focus, spawn) trigger the minimap to
+    /// show (only when `always_visible` is false). Floating windows aren't
+    /// rendered on the minimap, so surfacing it for transient popups, dialogs,
+    /// or returning focus from a popup is rarely useful.
+    pub show_for_floating_windows: bool,
 }
 
 impl Default for BehaviorConfig {
@@ -132,6 +137,7 @@ impl Default for BehaviorConfig {
             show_on_overview: true,
             always_visible: true,
             hide_timeout_ms: 2000,
+            show_for_floating_windows: false,
         }
     }
 }
@@ -216,9 +222,13 @@ active_workspace_border_color = "#89b4fa"    # Highlight border for active works
 active_workspace_border_width = 2            # Highlight border thickness ("all" mode)
 
 [behavior]
-show_on_overview = true   # Keep visible in Niri overview mode
-always_visible = true     # Always show minimap (false = only on focus change)
-hide_timeout_ms = 2000    # Milliseconds before hiding after focus change
+show_on_overview = true        # Keep visible in Niri overview mode
+always_visible = true          # Always show minimap (false = only on focus change)
+hide_timeout_ms = 2000         # Milliseconds before hiding after focus change
+show_for_floating_windows = false # When always_visible = false, surface the minimap for
+                                  # floating-window events (focus to/from a floating window,
+                                  # floating window spawn). Off by default since floating
+                                  # windows aren't drawn on the minimap.
 "##;
 
         std::fs::write(&config_path, default_config).with_context(|| {
@@ -297,6 +307,7 @@ mod tests {
         assert!(config.behavior.show_on_overview);
         assert!(config.behavior.always_visible);
         assert_eq!(config.behavior.hide_timeout_ms, 2000);
+        assert!(!config.behavior.show_for_floating_windows);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -211,6 +211,7 @@ fn apply_state_update(minimap: &MinimapWidget, update: StateUpdate) {
         } => {
             let window_id = window.id;
             let is_focused = window.is_focused;
+            let is_floating = window.is_floating;
             let mut is_new_window = false;
             let mut is_on_active_workspace = false;
 
@@ -240,10 +241,17 @@ fn apply_state_update(minimap: &MinimapWidget, update: StateUpdate) {
                 }
             });
 
-            // Only show the minimap for new windows on the active workspace
+            // Only show the minimap for new windows on the active workspace.
+            // Floating spawns are filtered by show_for_new_window when the
+            // show_for_floating_windows opt-out is in effect.
             if is_on_active_workspace && is_new_window {
-                minimap.show();
-                tracing::debug!("New window {} opened (focused: {})", window_id, is_focused);
+                minimap.show_for_new_window(is_floating);
+                tracing::debug!(
+                    "New window {} opened (focused: {}, floating: {})",
+                    window_id,
+                    is_focused,
+                    is_floating
+                );
             } else {
                 tracing::debug!("Window {} updated (focused: {})", window_id, is_focused);
             }

--- a/src/state/model.rs
+++ b/src/state/model.rs
@@ -65,6 +65,11 @@ impl MinimapState {
             .and_then(|id| self.workspaces.get(&id))
     }
 
+    /// Find a window by id across all workspaces.
+    pub fn find_window(&self, id: u64) -> Option<&Window> {
+        self.workspaces.values().find_map(|ws| ws.windows.get(&id))
+    }
+
     /// Workspaces sorted for display (by output, then idx).
     ///
     /// Workspaces without an output sort last; within the same output they

--- a/src/ui/minimap.rs
+++ b/src/ui/minimap.rs
@@ -72,19 +72,42 @@ impl MinimapWidget {
         }
     }
 
-    /// Show the minimap only if focus changed to a different window
-    /// Returns true if the minimap was shown
+    /// Show the minimap only if focus changed to a different window.
+    /// Returns true if the minimap was shown.
+    ///
+    /// When `behavior.show_for_floating_windows` is false (the default), focus
+    /// changes involving a floating window are suppressed *and* do not advance
+    /// `last_shown_focus_id`. This means returning focus from a popup back to
+    /// the previously-focused tile won't re-trigger a show — the prior tile
+    /// is still recorded as the last shown id.
     pub fn show_on_focus_change(&self, window_id: Option<u64>) -> bool {
         let last_id = self.last_shown_focus_id.get();
 
-        // Only show if focus changed to a different window
-        if window_id != last_id {
-            self.last_shown_focus_id.set(window_id);
-            self.show();
-            true
-        } else {
-            false
+        if window_id == last_id {
+            return false;
         }
+
+        if !self.config.borrow().behavior.show_for_floating_windows {
+            let is_floating = window_id
+                .and_then(|id| self.state.borrow().find_window(id).map(|w| w.is_floating))
+                .unwrap_or(false);
+            if is_floating {
+                return false;
+            }
+        }
+
+        self.last_shown_focus_id.set(window_id);
+        self.show();
+        true
+    }
+
+    /// Show the minimap for a newly-spawned window, respecting the
+    /// `show_for_floating_windows` opt-out.
+    pub fn show_for_new_window(&self, is_floating: bool) {
+        if is_floating && !self.config.borrow().behavior.show_for_floating_windows {
+            return;
+        }
+        self.show();
     }
 
     /// Hide the minimap


### PR DESCRIPTION
## Summary

- Adds `behavior.show_for_floating_windows` (default `false`). When `always_visible = false`, the minimap no longer surfaces for transient floating-window activity:
  - Focus moving **to** a floating window (popup, dialog, file picker).
  - Focus returning **from** a floating window to the previously-focused tile — `last_shown_focus_id` isn't advanced when a floating focus is suppressed, so the return is a no-op.
  - A new floating window being **spawned**.
- Floating windows aren't drawn on the minimap (see #6), so this activity would otherwise cause a distracting on/off flash.
- Set `show_for_floating_windows = true` to restore the prior always-show behavior.

The original issue (#24) scoped the option to focus-to-floating only; in review we expanded it to cover the symmetric "return from floating" and "floating spawn" cases under one flag, since they share the same UX motivation.

Closes #24.

## Test plan

- [x] `cargo build` clean
- [x] `cargo test` — 36/36 pass (existing suite + new default-value assertion)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] Manual: with `always_visible = false`, open a floating popup (e.g. a file picker) — minimap stays hidden; dismissing the popup back to the prior tile does not re-flash.
- [x] Manual: spawn a new floating window — minimap stays hidden.
- [x] Manual: focus changes between tiled windows still surface the minimap.
- [x] Manual: set `show_for_floating_windows = true`, hot-reload — prior always-show behavior is restored without restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)